### PR TITLE
CMake 通用库

### DIFF
--- a/3rd/CMakeLists.txt
+++ b/3rd/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(glfw)
 
-if (BUILD_TEST)
+if (${EXP_BUILD_TEST})
     add_subdirectory(googletest)
 endif()

--- a/Application/CMakeLists.txt
+++ b/Application/CMakeLists.txt
@@ -6,6 +6,9 @@ else()
 endif()
 
 file(GLOB APPLICATION_SOURCES Src/*.cpp)
-add_library(application ${APPLICATION_SOURCES})
-target_include_directories(application PUBLIC Include ${Vulkan_INCLUDE_DIRS})
-target_link_libraries(application glfw ${Vulkan_LIBRARIES})
+exp_add_library(
+    NAME application
+    SRCS ${APPLICATION_SOURCES}
+    PUBLIC_INC_DIRS Include ${Vulkan_INCLUDE_DIRS}
+    LIBS glfw ${Vulkan_LIBRARIES}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ project(Explosion)
 
 set(CMAKE_CXX_STANDARD 17)
 
+include(cmake/Explosion.cmake)
+
+option(CMAKE_VERBOSE_INFO "verbose info for cmake debug" ON)
+option(BUILD_TEST "Build Test" ON)
+
 if (NOT DEFINED ${CMAKE_BUILD_TYPE})
     set(CMAKE_BUILD_TYPE Debug)
 endif()
@@ -16,14 +21,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Bin)
 set(PROJECT_RUNTIME_DIRECTORY ${CMAKE_BINARY_DIR}/Bin)
 
 include(GenerateExportHeader)
-# [TODO] using api define in each module
+# TODO using api define in each module
 # set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 # set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 
 include_directories(${GEN_PRE_DIR})
 
 # options
-option(BUILD_TEST "Build Test" ON)
 if (${BUILD_TEST})
     enable_testing()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 include(cmake/Explosion.cmake)
 
-option(CMAKE_VERBOSE_INFO "verbose info for cmake debug" ON)
-option(BUILD_TEST "Build Test" ON)
+option(EXP_VERBOSE_INFO "verbose info for cmake debug" ON)
+option(EXP_BUILD_TEST "build test" ON)
 
 if (NOT DEFINED ${CMAKE_BUILD_TYPE})
     set(CMAKE_BUILD_TYPE Debug)
@@ -27,8 +27,8 @@ include(GenerateExportHeader)
 
 include_directories(${GEN_PRE_DIR})
 
-# options
-if (${BUILD_TEST})
+if (${EXP_BUILD_TEST})
+    message("-- enable testing")
     enable_testing()
 endif()
 

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -21,14 +21,18 @@ elseif (UNIX AND NOT APPLE)
     set(PLATFORM_SOURCES Src/RHI/Vulkan/Platform/VulkanLinux.cpp)
 endif()
 
-file(GLOB_RECURSE ENGINE_SOURCES Src/*.cpp)
-add_library(explosion ${ENGINE_SOURCES} ${PLATFORM_SOURCES})
-
-target_include_directories(explosion PUBLIC Include)
 if (APPLE)
-    target_link_libraries(explosion "-framework Cocoa")
+    set(PLATFORM_LIBS "-framework Cocoa")
+else()
+    set(PLATFORM_LIBS "")
 endif()
-target_link_libraries(explosion ${Vulkan_LIBRARIES})
+file(GLOB_RECURSE ENGINE_SOURCES Src/*.cpp)
+exp_add_library(
+    NAME explosion
+    SRCS ${ENGINE_SOURCES} ${PLATFORM_SOURCES}
+    PUBLIC_INC_DIRS Include
+    LIBS ${Vulkan_LIBRARIES} ${PLATFORM_LIBS}
+)
 
 # Unit Test
 add_subdirectory(Test)

--- a/Engine/Test/Common/CMakeLists.txt
+++ b/Engine/Test/Common/CMakeLists.txt
@@ -1,8 +1,7 @@
 file(GLOB COMMON_TEST_SOURCES *.cpp)
-add_executable(CommonTest ${COMMON_TEST_SOURCES})
-target_link_libraries(CommonTest gtest explosion)
-add_test(
+exp_add_test(
     NAME CommonTest
-    COMMAND CommonTest
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    SRCS ${COMMON_TEST_SOURCES}
+    LIBS gtest explosion
 )

--- a/Engine/Test/Driver/CMakeLists.txt
+++ b/Engine/Test/Driver/CMakeLists.txt
@@ -1,8 +1,7 @@
 file(GLOB_RECURSE DRIVER_TEST_SOURCES *.cpp)
-add_executable(DriverTest ${DRIVER_TEST_SOURCES})
-target_link_libraries(DriverTest gtest explosion)
-add_test(
+exp_add_test(
     NAME DriverTest
-    COMMAND DriverTest
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    SRCS ${DRIVER_TEST_SOURCES}
+    LIBS gtest explosion
 )

--- a/Engine/Test/Render/CMakeLists.txt
+++ b/Engine/Test/Render/CMakeLists.txt
@@ -1,8 +1,7 @@
 file(GLOB RENDER_TEST_SOURCES *.cpp)
-add_executable(RenderTest ${RENDER_TEST_SOURCES})
-target_link_libraries(RenderTest gtest explosion)
-add_test(
+exp_add_test(
     NAME RenderTest
-    COMMAND RenderTest
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    SRCS ${RENDER_TEST_SOURCES}
+    LIBS gtest explosion
 )

--- a/Plugins/PassBuilder/CMakeLists.txt
+++ b/Plugins/PassBuilder/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 set(PLUG_TARGET PassBuilder)
 
 project(${PLUG_TARGET})
@@ -7,48 +6,29 @@ set(THIRD_PARTY_INC
     ${PROJECT_ROOT}/3rd/rapidjson/include
 )
 
-include_directories(Include)
-include_directories(${PROJECT_ROOT}/Engine/Include)
-include_directories(${THIRD_PARTY_INC})
-
 file(GLOB_RECURSE SRC_FILES Src/*.cpp Src/*.h)
 file(GLOB_RECURSE INC_FILES Include/*h)
 list(APPEND INC_FILES ${GEN_PRE_DIR}/PassBuilderApi.h)
 
-add_library(${PLUG_TARGET} SHARED
-    ${SRC_FILES}
-    ${INC_FILES}
+exp_add_library(
+    NAME ${PLUG_TARGET}
+    TYPE SHARED
+    SRCS ${SRC_FILES} ${INC_FILES}
+    PUBLIC_INC_DIRS Include ${PROJECT_ROOT}/Engine/Include ${THIRD_PARTY_INC}
+    LIBS explosion
+)
+
+set(UNIT_TEST PassTest)
+file(GLOB_RECURSE TEST_FILES Test/*)
+exp_add_test(
+    NAME ${UNIT_TEST}
+    WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Test
+    SRCS ${TEST_FILES}
+    INC_DIRS ${PROJECT_ROOT}/3rd/googletest/googletest/include
+    LIBS ${PLUG_TARGET} gtest
 )
 
 generate_export_header(${PLUG_TARGET}
     EXPORT_MACRO_NAME PASS_API
     EXPORT_FILE_NAME ${GEN_PRE_DIR}/PassBuilderApi.h
 )
-
-target_link_libraries(${PLUG_TARGET}
-    explosion
-)
-
-## TEST
-if (BUILD_TEST)
-    file(GLOB_RECURSE TEST_FILES Test/*)
-
-    include_directories(${PROJECT_ROOT}/3rd/googletest/include/gtest)
-
-    set(UNIT_TEST PassTest)
-
-    add_executable(${UNIT_TEST}
-        ${TEST_FILES}
-    )
-
-    target_link_libraries(${UNIT_TEST}
-        ${PLUG_TARGET}
-        gtest
-    )
-
-    add_test(
-        NAME ${UNIT_TEST}
-        COMMAND ${UNIT_TEST}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test
-    )
-endif ()

--- a/Plugins/PassBuilder/Test/PassTest.cpp
+++ b/Plugins/PassBuilder/Test/PassTest.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "PassLoader.h"
 
 class PassLoaderTest : public testing::Test {

--- a/Samples/1-Triangle/CMakeLists.txt
+++ b/Samples/1-Triangle/CMakeLists.txt
@@ -1,6 +1,9 @@
 file(GLOB TRIANGLE_SOURCES Main.cpp)
-add_executable(1-Triangle ${TRIANGLE_SOURCES})
-target_link_libraries(1-Triangle explosion application)
+exp_add_executable(
+    NAME 1-Triangle
+    SRCS ${TRIANGLE_SOURCES}
+    LIBS explosion application
+)
 add_custom_command(
     TARGET 1-Triangle PRE_BUILD
     COMMAND glslc -fshader-stage=vertex ${CMAKE_CURRENT_SOURCE_DIR}/Vertex.glsl -o ${PROJECT_RUNTIME_DIRECTORY}/1-Triangle-Vertex.spv

--- a/cmake/Explosion.cmake
+++ b/cmake/Explosion.cmake
@@ -1,0 +1,97 @@
+function(exp_add_executable)
+    cmake_parse_arguments(
+        PARAMS
+        ""
+        "NAME"
+        "SRCS;INC_DIRS;LIBS"
+        ${ARGN}
+    )
+
+    if (CMAKE_VERBOSE_INFO)
+        message("")
+        message("[exp_add_executable begin]")
+        message("-name: ${PARAMS_NAME}")
+        message("-sources: ${PARAMS_SRCS}")
+        message("-include dirs: ${PARAMS_INC_DIRS}")
+        message("-libs: ${PARAMS_LIBS}")
+        message("[exp_add_executable end]")
+        message("")
+    endif()
+
+    add_executable(
+        ${PARAMS_NAME}
+        ${PARAMS_SRCS}
+    )
+    target_include_directories(${PARAMS_NAME} PRIVATE ${PARAMS_INC_DIRS})
+    target_link_libraries(${PARAMS_NAME} ${PARAMS_LIBS})
+endfunction()
+
+function(exp_add_test)
+    if (NOT BUILD_TEST)
+        return()
+    endif()
+
+    cmake_parse_arguments(
+        PARAMS
+        ""
+        "NAME;WORKING_DIR"
+        "SRCS;INC_DIRS;LIBS"
+        ${ARGN}
+    )
+
+    if (CMAKE_VERBOSE_INFO)
+        message("")
+        message("[exp_add_test begin]")
+        message("-name: ${PARAMS_NAME}")
+        message("-working dir: ${PARAMS_WORKING_DIR}")
+        message("-sources: ${PARAMS_SRCS}")
+        message("-include dirs: ${PARAMS_INC_DIRS}")
+        message("-libs: ${PARAMS_LIBS}")
+        message("[exp_add_test end]")
+        message("")
+    endif()
+
+    add_executable(
+        ${PARAMS_NAME}
+        ${PARAMS_SRCS}
+    )
+    target_include_directories(${PARAMS_NAME} PRIVATE ${PARAMS_INC_DIRS})
+    target_link_libraries(${PARAMS_NAME} ${PARAMS_LIBS})
+    add_test(
+        NAME ${PARAMS_NAME}
+        COMMAND ${PARAMS_NAME}
+        WORKING_DIRECTORY ${PARAMS_WORKING_DIR}
+    )
+endfunction()
+
+function(exp_add_library)
+    cmake_parse_arguments(
+        PARAMS
+        ""
+        "NAME;TYPE"
+        "SRCS;PRIVATE_INC_DIRS;PUBLIC_INC_DIRS;LIBS"
+        ${ARGN}
+    )
+
+    if (CMAKE_VERBOSE_INFO)
+        message("")
+        message("[exp_add_library begin]")
+        message("-name: ${PARAMS_NAME}")
+        message("-type: ${PARAMS_TYPE}")
+        message("-sources: ${PARAMS_SRCS}")
+        message("-private include dirs: ${PARAMS_PRIVATE_INC_DIRS}")
+        message("-public include dirs: ${PARAMS_PUBLIC_INC_DIRS}")
+        message("-libs: ${PARAMS_LIBS}")
+        message("[exp_add_library end]")
+        message("")
+    endif()
+
+    add_library(
+        ${PARAMS_NAME}
+        ${PARAMS_TYPE}
+        ${PARAMS_SRCS}
+    )
+    target_include_directories(${PARAMS_NAME} PRIVATE ${PARAMS_PRIVATE_INC_DIRS})
+    target_include_directories(${PARAMS_NAME} PUBLIC ${PARAMS_PUBLIC_INC_DIRS})
+    target_link_libraries(${PARAMS_NAME} ${PARAMS_LIBS})
+endfunction()

--- a/cmake/Explosion.cmake
+++ b/cmake/Explosion.cmake
@@ -7,7 +7,7 @@ function(exp_add_executable)
         ${ARGN}
     )
 
-    if (CMAKE_VERBOSE_INFO)
+    if (${EXP_VERBOSE_INFO})
         message("")
         message("[exp_add_executable begin]")
         message("-name: ${PARAMS_NAME}")
@@ -27,7 +27,7 @@ function(exp_add_executable)
 endfunction()
 
 function(exp_add_test)
-    if (NOT BUILD_TEST)
+    if (NOT ${EXP_BUILD_TEST})
         return()
     endif()
 
@@ -39,7 +39,7 @@ function(exp_add_test)
         ${ARGN}
     )
 
-    if (CMAKE_VERBOSE_INFO)
+    if (${EXP_VERBOSE_INFO})
         message("")
         message("[exp_add_test begin]")
         message("-name: ${PARAMS_NAME}")
@@ -73,7 +73,7 @@ function(exp_add_library)
         ${ARGN}
     )
 
-    if (CMAKE_VERBOSE_INFO)
+    if (${EXP_VERBOSE_INFO})
         message("")
         message("[exp_add_library begin]")
         message("-name: ${PARAMS_NAME}")


### PR DESCRIPTION
参见 Issue #52，添加了 Explosion CMake 通用库，目前添加的方法有

```cmake
exp_add_executable()
exp_add_library()
exp_add_test()
```

他们的使用方法如下：

```cmake
exp_add_executable(
    NAME ${TARGET_NAME}
    SRCS ${TARGET_SOURCES}
    INC_DIRS ${TARGET_INCLUDE_DIRS}
    LIBS ${TARGET_LIBS}
)

exp_add_library(
    NAME ${TARGET_NAME}
    TYPE ${TARGET_TYPE}
    SRCS ${TARGET_SOURCES}
    PRIVATE_INC_DIRS ${TARGET_PRIVATE_INCLUDE_DIRS}
    PUBLIC_INC_DIRS ${TARGET_PUBLIC_INCLUDE_DIRS}
    LIB ${TARGET_LIBS}
)

exp_add_test(
    NAME ${TARGET_NAME}
    WORKING_DIR ${TARGET_WORKING_DIR}
    SRCS ${TARGET_SOURCES}
    INC_DIRS ${TARGET_INCLUDE_DIRS}
    LIB ${TARGET_LIBS}
)
```

现在可以更方便地添加可执行文件、库文件、单元测试用例了。